### PR TITLE
Fix names to avoid validation warnings in terraform init

### DIFF
--- a/terraform/gcp/outputs.tf
+++ b/terraform/gcp/outputs.tf
@@ -2,7 +2,7 @@
 ################# Outputs #################
 ###########################################
 
-output "REST Proxy" {
+output "REST_Proxy" {
 
   value = "${var.instance_count["rest_proxy"] >= 1
            ? "${join(",", formatlist("http://%s", google_compute_global_address.rest_proxy.*.address))}"
@@ -10,7 +10,7 @@ output "REST Proxy" {
 
 }
 
-output "Kafka Connect" {
+output "Kafka_Connect" {
 
   value = "${var.instance_count["kafka_connect"] >= 1
            ? "${join(",", formatlist("http://%s", google_compute_global_address.kafka_connect.*.address))}"
@@ -18,7 +18,7 @@ output "Kafka Connect" {
 
 }
 
-output "KSQL Server" {
+output "KSQL_Server" {
 
   value = "${var.instance_count["ksql_server"] >= 1
            ? "${join(",", formatlist("http://%s", google_compute_global_address.ksql_server.*.address))}"
@@ -26,7 +26,7 @@ output "KSQL Server" {
 
 }
 
-output "Control Center" {
+output "Control_Center" {
 
   value = "${var.instance_count["control_center"] >= 1
            ? "${join(",", formatlist("http://%s", google_compute_global_address.control_center.*.address))}"


### PR DESCRIPTION
`init output` was: 

```
Terraform has initialized, but configuration upgrades may be needed.

Terraform found syntax errors in the configuration that prevented full
initialization. If you've recently upgraded to Terraform v0.12, this may be
because your configuration uses syntax constructs that are no longer valid,
and so must be updated before full initialization is possible.
```

Validate: 
```
$ terraform validate

Error: Invalid output name

  on outputs.tf line 5, in output "REST Proxy":
   5: output "REST Proxy" {

A name must start with a letter and may contain only letters, digits,
underscores, and dashes.
```

This change just replaces spaces in the names with underscores. 