### PR TITLE
fix for Error: "version": required field is not set

### DIFF
--- a/terraform/gcp/compute.tf
+++ b/terraform/gcp/compute.tf
@@ -50,11 +50,14 @@ resource "google_compute_region_instance_group_manager" "rest_proxy" {
   count = var.instance_count["rest_proxy"] > 0 ? var.instance_count["rest_proxy"] : 0
 
   name                      = "rest-proxy-instance-group-${var.global_prefix}"
-  instance_template         = google_compute_instance_template.rest_proxy[0].self_link
   base_instance_name        = "${var.global_prefix}-rest-proxy"
   region                    = local.region
   distribution_policy_zones = data.google_compute_zones.available.names
   target_size               = var.instance_count["rest_proxy"]
+
+  version {
+    instance_template = google_compute_instance_template.rest_proxy[0].self_link
+  }
 
   named_port {
     name = "http"
@@ -149,11 +152,14 @@ resource "google_compute_region_instance_group_manager" "kafka_connect" {
   count = var.instance_count["kafka_connect"] > 0 ? var.instance_count["kafka_connect"] : 0
 
   name                      = "kafka-connect-instance-group-${var.global_prefix}"
-  instance_template         = google_compute_instance_template.kafka_connect[0].self_link
   base_instance_name        = "${var.global_prefix}-kafka-connect"
   region                    = local.region
   distribution_policy_zones = data.google_compute_zones.available.names
   target_size               = var.instance_count["kafka_connect"]
+
+  version {
+    instance_template = google_compute_instance_template.kafka_connect[0].self_link
+  }
 
   named_port {
     name = "http"
@@ -248,11 +254,14 @@ resource "google_compute_region_instance_group_manager" "ksql_server" {
   count = var.instance_count["ksql_server"] > 0 ? var.instance_count["ksql_server"] : 0
 
   name                      = "ksql-server-instance-group-${var.global_prefix}"
-  instance_template         = google_compute_instance_template.ksql_server[0].self_link
   base_instance_name        = "${var.global_prefix}-ksql-server"
   region                    = local.region
   distribution_policy_zones = data.google_compute_zones.available.names
   target_size               = var.instance_count["ksql_server"]
+
+  version {
+    instance_template = google_compute_instance_template.ksql_server[0].self_link
+  }
 
   named_port {
     name = "http"
@@ -347,11 +356,14 @@ resource "google_compute_region_instance_group_manager" "control_center" {
   count = var.instance_count["control_center"] > 0 ? var.instance_count["control_center"] : 0
 
   name                      = "control-center-instance-group-${var.global_prefix}"
-  instance_template         = google_compute_instance_template.control_center[0].self_link
   base_instance_name        = "${var.global_prefix}-control-center"
   region                    = local.region
   distribution_policy_zones = data.google_compute_zones.available.names
   target_size               = var.instance_count["control_center"]
+
+  version {
+    instance_template = google_compute_instance_template.control_center[0].self_link
+  }
 
   named_port {
     name = "http"


### PR DESCRIPTION
Terraform version used:

```bash
$ terraform -v

Terraform v0.12.20
+ provider.google v3.8.0
+ provider.template v2.1.2
```

Getting error:

```log
Error: "version": required field is not set

  on compute.tf line 49, in resource "google_compute_region_instance_group_manager" "rest_proxy":
  49: resource "google_compute_region_instance_group_manager" "rest_proxy" {



Error: "instance_template": this field cannot be set

  on compute.tf line 49, in resource "google_compute_region_instance_group_manager" "rest_proxy":
  49: resource "google_compute_region_instance_group_manager" "rest_proxy" {



Error: "version": required field is not set

  on compute.tf line 148, in resource "google_compute_region_instance_group_manager" "kafka_connect":
 148: resource "google_compute_region_instance_group_manager" "kafka_connect" {



Error: "instance_template": this field cannot be set

  on compute.tf line 148, in resource "google_compute_region_instance_group_manager" "kafka_connect":
 148: resource "google_compute_region_instance_group_manager" "kafka_connect" {



Error: "version": required field is not set

  on compute.tf line 247, in resource "google_compute_region_instance_group_manager" "ksql_server":
 247: resource "google_compute_region_instance_group_manager" "ksql_server" {



Error: "instance_template": this field cannot be set

  on compute.tf line 247, in resource "google_compute_region_instance_group_manager" "ksql_server":
 247: resource "google_compute_region_instance_group_manager" "ksql_server" {



Error: "version": required field is not set

  on compute.tf line 346, in resource "google_compute_region_instance_group_manager" "control_center":
 346: resource "google_compute_region_instance_group_manager" "control_center" {



Error: "instance_template": this field cannot be set

  on compute.tf line 346, in resource "google_compute_region_instance_group_manager" "control_center":
 346: resource "google_compute_region_instance_group_manager" "control_center" {

```

`version` is now mandatory in [google_compute_region_instance_group_manager](https://www.terraform.io/docs/providers/google/r/compute_region_instance_group_manager.html)