### PR TITLE
Set google provider version

### DIFF
--- a/terraform/gcp/versions.tf
+++ b/terraform/gcp/versions.tf
@@ -1,4 +1,8 @@
 
 terraform {
+  required_providers {
+    google = "= 2.20.3"
+  }
+
   required_version = ">= 0.12"
 }


### PR DESCRIPTION
The latest google plugin version is not backward compatible with the current code in this project

This project uses the default google plugin version (3.20.0). 

The goal of this pr is to use a working google plugin version instead

<details>
$ terraform init

Initializing the backend...

Initializing provider plugins...
- Checking for available provider plugins...
- Downloading plugin for provider "google" (hashicorp/google) 3.20.0...
- Downloading plugin for provider "template" (hashicorp/template) 2.1.2...

The following providers do not have any version constraints in configuration,
so the latest version was installed.

To prevent automatic upgrades to new major versions that may contain breaking
changes, it is recommended to add version = "..." constraints to the
corresponding provider blocks in configuration, with the constraint strings
suggested below.

* provider.google: version = "~> 3.20"
* provider.template: version = "~> 2.1"

Terraform has been successfully initialized!

You may now begin working with Terraform. Try running "terraform plan" to see
any changes that are required for your infrastructure. All Terraform commands
should now work.

If you ever set or change modules or backend configuration for Terraform,
rerun this command to reinitialize your working directory. If you forget, other
commands will detect it and remind you to do so if necessary.

</details>

Plan fails

<details>
[...]
Error: "version": required field is not set

  on compute.tf line 148, in resource "google_compute_region_instance_group_manager" "kafka_connect":
 148: resource "google_compute_region_instance_group_manager" "kafka_connect" {

[...]
</details>

From the doc: https://www.terraform.io/docs/providers/google/r/compute_region_instance_group_manager.html

```
version - (Required) Application versions managed by this instance group. Each version deals with a specific instance template, allowing canary release scenarios. Structure is documented below.
```

I was able to make it work with the latest version 2.x.y google plugin version

Related to https://github.com/confluentinc/ccloud-tools/pull/23

