### PR TITLE
Updating code owners to devx

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,2 @@
 # See go/codeowners - automatically generated for confluentinc/ccloud-tools:
-*	@elismaga
-*	@vdesabou
+*	@devx


### PR DESCRIPTION
I am not the owner of this repo and have never worked on it so I am not sure why I am listed in this code owners file. I believe the developer experience team owns this repo so I am setting them as the code owners.